### PR TITLE
Remove print side effect from constants

### DIFF
--- a/constants/constants.py
+++ b/constants/constants.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 ROOT_DIR = Path(__file__).parent.parent
-print(ROOT_DIR)
 
 WIDTH = 18 # the board's width
 HEIGHT = 10 # the board's height


### PR DESCRIPTION
## Summary
- avoid printing ROOT_DIR when importing the constants module

## Testing
- `PYTHONPATH=..:. python unit_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e41052f8833392ce521d734a2a9a