### PR TITLE
Add tile prediction mode

### DIFF
--- a/data/system_prompt_tiles.txt
+++ b/data/system_prompt_tiles.txt
@@ -1,0 +1,4 @@
+You are an assistant for a hexagonal drawing game.
+Given natural language instructions, output which tiles should be colored.
+Reply only with a list of tuples in the form (row, column, color).
+Rows and columns start at 1. Allowed colors are ['white','black','yellow','green','red','blue','purple','orange'].

--- a/data/user_message_tiles.txt
+++ b/data/user_message_tiles.txt
@@ -1,0 +1,7 @@
+##### CONTEXT (completed instructions so far)
+{HISTORY_BLOCK}
+
+##### NEXT INSTRUCTION
+{NEXT_STEP}
+
+Provide the tiles as a list of (row,column,color) tuples:

--- a/gpt/experiment.py
+++ b/gpt/experiment.py
@@ -161,11 +161,19 @@ def run_step(cfg: argparse.Namespace, sys_prompt: str, user_tmpl: str,
                 return log, False, code, image_path  # keep previous image
 
 
-def run_step_tiles(cfg: argparse.Namespace, sys_prompt: str, user_tmpl: str,
-                   instr: str, history: List[str], board: List[int],
-                   gold_board: List[int], image_path: Optional[Path],
-                   out_dir: Path, step_idx: int, run_ts: str)
-                   -> tuple[Dict, bool, List[int], Path | None]:
+def run_step_tiles(
+    cfg: argparse.Namespace,
+    sys_prompt: str,
+    user_tmpl: str,
+    instr: str,
+    history: List[str],
+    board: List[int],
+    gold_board: List[int],
+    image_path: Optional[Path],
+    out_dir: Path,
+    step_idx: int,
+    run_ts: str
+) -> tuple[Dict, bool, List[int], Optional[Path]]:
     """Prompt GPT for tile predictions and update board state."""
     attempt = 0
     from constants.constants import COLORS, WIDTH, HEIGHT

--- a/tests/test_parse_tile_actions.py
+++ b/tests/test_parse_tile_actions.py
@@ -1,0 +1,11 @@
+from gpt.runner_utils import parse_tile_actions
+
+
+def test_parse_tile_actions_tuple_list():
+    text = "[(1,2,'red'), (3,4,\"blue\")]"
+    assert parse_tile_actions(text) == [(1,2,'red'), (3,4,'blue')]
+
+
+def test_parse_tile_actions_regex():
+    text = "(1,2,green) (5,6,orange)"
+    assert parse_tile_actions(text) == [(1,2,'green'), (5,6,'orange')]


### PR DESCRIPTION
- allow running experiment in a new `tiles` mode
- load templates for tile prediction prompts
- parse model output into `(row,column,color)` tuples
- test tile parsing logic
- drop unused full-run tiles mode